### PR TITLE
Reorganize calculator input panel — group inputs by logical function

### DIFF
--- a/kalkulator-lima.html
+++ b/kalkulator-lima.html
@@ -24,6 +24,15 @@
   .setting-group{display:flex;align-items:center;gap:8px}
   .setting-group input{width:120px;text-align:center;font-size:18px;font-weight:600}
   .setting-group-sm input{width:80px;text-align:center;font-size:15px;font-weight:600}
+  /* --- Grouped settings panel --- */
+  .settings-section{padding:16px 20px;border-top:1px solid rgba(255,255,255,.06)}
+  .settings-section:first-child{border-top:none}
+  .settings-section-header{font-size:11px;font-weight:600;color:#4a5a7a;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px}
+  .settings-section-body{display:flex;flex-wrap:wrap;gap:16px 28px;align-items:flex-end}
+  .settings-section-body--2col{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .settings-field{display:flex;flex-direction:column;gap:6px}
+  .field-label{font-size:13px;font-weight:500;color:#8899bb;white-space:nowrap;text-align:left}
+  .field-control{display:flex;align-items:center;gap:8px}
   .unit-label{color:#5a6a8a;font-size:14px;white-space:nowrap}
   .unit-toggle{display:flex;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:8px;overflow:hidden}
   .unit-toggle button{background:none;border:none;color:#5a6a8a;font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;padding:8px 16px;cursor:pointer;transition:all .2s}
@@ -140,26 +149,59 @@
   </div>
 
   <div class="card settings-card">
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot"></div><label class="label-upper" for="sirinaRolne">Širina rolne</label></div>
-      <div class="setting-group"><input type="number" id="sirinaRolne" value="125" min="1" aria-label="Širina rolne" oninput="debouncedCalc()"><span class="unit-label" id="rolnaUnit">cm</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><label class="label-upper">Jedinica</label>
-        <div class="unit-toggle" id="unitToggle" role="group" aria-label="Izbor jedinice mere"><button class="active" onclick="setUnit('cm')">cm</button><button onclick="setUnit('mm')">mm</button></div>
+    <!-- Materijal -->
+    <div class="settings-section">
+      <div class="settings-section-header">Materijal</div>
+      <div class="settings-section-body">
+        <div class="settings-field">
+          <label class="field-label" for="sirinaRolne">Širina rolne</label>
+          <div class="field-control">
+            <div class="setting-group"><input type="number" id="sirinaRolne" value="125" min="1" aria-label="Širina rolne" oninput="debouncedCalc()"><span class="unit-label" id="rolnaUnit">cm</span></div>
+            <div class="unit-toggle" id="unitToggle" role="group" aria-label="Izbor jedinice mere"><button class="active" onclick="setUnit('cm')">cm</button><button onclick="setUnit('mm')">mm</button></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label" for="jedCena">Jed. cena / m</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="jedCena" value="1100" min="0" step="10" aria-label="Jedinična cena RSD/m" oninput="debouncedCalc()"><span class="unit-label">RSD</span></div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#ff9050;box-shadow:0 0 8px rgba(255,144,80,.4)"></div><label class="label-upper" for="kerfInput">Razmak reza</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="kerfInput" value="2" min="0" step="0.5" aria-label="Razmak reza mm" oninput="debouncedCalc()"><span class="unit-label">mm</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><div class="dot" style="background:#ff9050;box-shadow:0 0 8px rgba(255,144,80,.4)"></div><label class="label-upper" for="safetyMargin">Ivica sigurnosti</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="safetyMargin" value="5" min="0" step="1" aria-label="Ivica sigurnosti mm×2" oninput="debouncedCalc()"><span class="unit-label">mm ×2</span></div>
+    <!-- Parametri sečenja -->
+    <div class="settings-section">
+      <div class="settings-section-header">Parametri sečenja</div>
+      <div class="settings-section-body settings-section-body--2col">
+        <div class="settings-field">
+          <label class="field-label" for="kerfInput">Razmak reza</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="kerfInput" value="2" min="0" step="0.5" aria-label="Razmak reza mm" oninput="debouncedCalc()"><span class="unit-label">mm</span></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label" for="safetyMargin">Ivica sigurnosti</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="safetyMargin" value="5" min="0" step="1" aria-label="Ivica sigurnosti mm×2" oninput="debouncedCalc()"><span class="unit-label">mm ×2</span></div>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#e0c64f;box-shadow:0 0 8px rgba(224,198,79,.4)"></div><label class="label-upper" for="cenaSavijanja">Cena savijanja / m</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="cenaSavijanja" value="150" min="0" aria-label="Cena savijanja RSD/m" oninput="debouncedCalc()"><span class="unit-label">RSD</span></div>
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#e0c64f;box-shadow:0 0 8px rgba(224,198,79,.4)"></div><label class="label-upper" for="jedCena">Jed. cena / m</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="jedCena" value="1100" min="0" step="10" aria-label="Jedinična cena RSD/m" oninput="debouncedCalc()"><span class="unit-label">RSD</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><label class="label-upper">Mešanje dužina</label>
-        <div class="unit-toggle" id="mixToggle" role="group" aria-label="Režim mešanja"><button class="active" onclick="setMixMode(true)">Kombinuj</button><button onclick="setMixMode(false)">Strict</button></div>
+    <!-- Savijanje i mešanje -->
+    <div class="settings-section">
+      <div class="settings-section-header">Savijanje i mešanje</div>
+      <div class="settings-section-body">
+        <div class="settings-field">
+          <label class="field-label" for="cenaSavijanja">Cena savijanja / m</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="cenaSavijanja" value="150" min="0" aria-label="Cena savijanja RSD/m" oninput="debouncedCalc()"><span class="unit-label">RSD</span></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label">Mešanje dužina</label>
+          <div class="field-control">
+            <div class="unit-toggle" id="mixToggle" role="group" aria-label="Režim mešanja"><button class="active" onclick="setMixMode(true)">Kombinuj</button><button onclick="setMixMode(false)">Strict</button></div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/nesting-calculator-en.html
+++ b/nesting-calculator-en.html
@@ -24,6 +24,15 @@
   .setting-group{display:flex;align-items:center;gap:8px}
   .setting-group input{width:120px;text-align:center;font-size:18px;font-weight:600}
   .setting-group-sm input{width:80px;text-align:center;font-size:15px;font-weight:600}
+  /* --- Grouped settings panel --- */
+  .settings-section{padding:16px 20px;border-top:1px solid rgba(255,255,255,.06)}
+  .settings-section:first-child{border-top:none}
+  .settings-section-header{font-size:11px;font-weight:600;color:#4a5a7a;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px}
+  .settings-section-body{display:flex;flex-wrap:wrap;gap:16px 28px;align-items:flex-end}
+  .settings-section-body--2col{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .settings-field{display:flex;flex-direction:column;gap:6px}
+  .field-label{font-size:13px;font-weight:500;color:#8899bb;white-space:nowrap;text-align:left}
+  .field-control{display:flex;align-items:center;gap:8px}
   .unit-label{color:#5a6a8a;font-size:14px;white-space:nowrap}
   .unit-toggle{display:flex;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:8px;overflow:hidden}
   .unit-toggle button{background:none;border:none;color:#5a6a8a;font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;padding:8px 16px;cursor:pointer;transition:all .2s}
@@ -140,26 +149,59 @@
   </div>
 
   <div class="card settings-card">
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot"></div><label class="label-upper" for="sirinaRolne">Coil Width</label></div>
-      <div class="setting-group"><input type="number" id="sirinaRolne" value="1250" min="1" aria-label="Coil width" oninput="debouncedCalc()"><span class="unit-label" id="rolnaUnit">mm</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><label class="label-upper">Unit</label>
-        <div class="unit-toggle" id="unitToggle" role="group" aria-label="Unit selection"><button onclick="setUnit('cm')">cm</button><button class="active" onclick="setUnit('mm')">mm</button></div>
+    <!-- Material -->
+    <div class="settings-section">
+      <div class="settings-section-header">Material</div>
+      <div class="settings-section-body">
+        <div class="settings-field">
+          <label class="field-label" for="sirinaRolne">Coil width</label>
+          <div class="field-control">
+            <div class="setting-group"><input type="number" id="sirinaRolne" value="1250" min="1" aria-label="Coil width" oninput="debouncedCalc()"><span class="unit-label" id="rolnaUnit">mm</span></div>
+            <div class="unit-toggle" id="unitToggle" role="group" aria-label="Unit selection"><button onclick="setUnit('cm')">cm</button><button class="active" onclick="setUnit('mm')">mm</button></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label" for="jedCena">Unit price / m</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="jedCena" value="10" min="0" step="0.5" aria-label="Unit price USD/m" oninput="debouncedCalc()"><span class="unit-label">USD</span></div>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#ff9050;box-shadow:0 0 8px rgba(255,144,80,.4)"></div><label class="label-upper" for="kerfInput">Blade Kerf</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="kerfInput" value="2" min="0" step="0.5" aria-label="Blade kerf mm" oninput="debouncedCalc()"><span class="unit-label">mm</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><div class="dot" style="background:#ff9050;box-shadow:0 0 8px rgba(255,144,80,.4)"></div><label class="label-upper" for="safetyMargin">Edge Margin</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="safetyMargin" value="5" min="0" step="1" aria-label="Edge safety margin mm per side" oninput="debouncedCalc()"><span class="unit-label">mm ×2</span></div>
+    <!-- Cutting parameters -->
+    <div class="settings-section">
+      <div class="settings-section-header">Cutting parameters</div>
+      <div class="settings-section-body settings-section-body--2col">
+        <div class="settings-field">
+          <label class="field-label" for="kerfInput">Blade kerf</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="kerfInput" value="2" min="0" step="0.5" aria-label="Blade kerf mm" oninput="debouncedCalc()"><span class="unit-label">mm</span></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label" for="safetyMargin">Edge margin</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="safetyMargin" value="5" min="0" step="1" aria-label="Edge safety margin mm per side" oninput="debouncedCalc()"><span class="unit-label">mm ×2</span></div>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="settings-row">
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#e0c64f;box-shadow:0 0 8px rgba(224,198,79,.4)"></div><label class="label-upper" for="cenaSavijanja">Bending Cost / m</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="cenaSavijanja" value="1.5" min="0" step="0.1" aria-label="Bending cost per linear meter" oninput="debouncedCalc()"><span class="unit-label">USD</span></div>
-      <div style="display:flex;align-items:center;gap:8px"><div class="dot" style="background:#e0c64f;box-shadow:0 0 8px rgba(224,198,79,.4)"></div><label class="label-upper" for="jedCena">Unit Price / m</label></div>
-      <div class="setting-group setting-group-sm"><input type="number" id="jedCena" value="10" min="0" step="0.5" aria-label="Unit price USD/m" oninput="debouncedCalc()"><span class="unit-label">USD</span></div>
-      <div style="display:flex;align-items:center;gap:8px;margin-left:auto"><label class="label-upper">Length Mixing</label>
-        <div class="unit-toggle" id="mixToggle" role="group" aria-label="Mixing mode"><button class="active" onclick="setMixMode(true)">Combined</button><button onclick="setMixMode(false)">Strict</button></div>
+    <!-- Bending and mixing -->
+    <div class="settings-section">
+      <div class="settings-section-header">Bending and mixing</div>
+      <div class="settings-section-body">
+        <div class="settings-field">
+          <label class="field-label" for="cenaSavijanja">Bending cost / m</label>
+          <div class="field-control">
+            <div class="setting-group setting-group-sm"><input type="number" id="cenaSavijanja" value="1.5" min="0" step="0.1" aria-label="Bending cost per linear meter" oninput="debouncedCalc()"><span class="unit-label">USD</span></div>
+          </div>
+        </div>
+        <div class="settings-field">
+          <label class="field-label">Length mixing</label>
+          <div class="field-control">
+            <div class="unit-toggle" id="mixToggle" role="group" aria-label="Mixing mode"><button class="active" onclick="setMixMode(true)">Combined</button><button onclick="setMixMode(false)">Strict</button></div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Added 3 labeled sections: Material, Cutting parameters, Bending and mixing (SR: Materijal, Parametri sečenja, Savijanje i mešanje)
- Moved unit toggle adjacent to coil width input instead of isolated top-right
- Converted field labels from uppercase CSS to sentence case
- Removed colored indicator dots from settings inputs
- Applied new CSS: settings-section, settings-field, field-label, field-control classes with ~1.5rem spacing, left-aligned labels

Closes #3

https://claude.ai/code/session_01VgRnhgdZL4SZ1SR3i2iA5d