### PR TITLE
Fix toggle overlap in opcije panel; shorten ivica sigurnosti label

### DIFF
--- a/sr/index.html
+++ b/sr/index.html
@@ -418,6 +418,8 @@ body {
 .field-unit { position:absolute; right:9px; color:var(--text-3); font-size:10px; font-family:'DM Sans',sans-serif; pointer-events:none; white-space:nowrap; }
 .toggle-group { display:inline-flex; background:var(--bg2); border:1px solid var(--border2); border-radius:var(--radius); overflow:hidden; height:var(--input-h); width:fit-content; }
 .toggle-group button { background:none; border:none; color:var(--text-3); font-family:'DM Sans',sans-serif; font-size:12px; font-weight:600; padding:0 11px; cursor:pointer; transition:all .15s; white-space:nowrap; line-height:var(--input-h); }
+.opts-col .toggle-group { width:100%; }
+.opts-col .toggle-group button { flex:1; text-align:center; }
 .toggle-group button.active { background:var(--teal-dim); color:var(--teal); }
 .toggle-group button:hover:not(.active) { background:var(--surface2); color:var(--text-2); }
 .opts-panel-inner { padding:12px 16px 14px; }
@@ -989,7 +991,7 @@ body {
           </div>
         </div>
         <div class="field">
-          <label class="field-label" for="safetyMargin">Ivica sigurnosti (×2)</label>
+          <label class="field-label" for="safetyMargin">Margina (×2)</label>
           <div class="field-input-wrap">
             <input type="number" id="safetyMargin" value="2" min="0" step="1" aria-label="Edge margin mm per side" oninput="debouncedCalc()">
             <span class="field-unit" id="safetyUnit">mm</span>


### PR DESCRIPTION
- Make toggle-group fill full column width in opts-col so Strict/Kombinuj,
  Metrički/Imp. and mm/cm rows no longer overlap each other
- Rename 'Ivica sigurnosti (×2)' → 'Margina (×2)' to fit in one line

https://claude.ai/code/session_01SrcMyG5939n7Pvk5atAS3m